### PR TITLE
get_HIIbubbles.c: Fix wrongly used global_N_halo and global_N_smooth

### DIFF
--- a/get_HIIbubbles.c
+++ b/get_HIIbubbles.c
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
       halo_map[i] =0.0;
     }
 
-    sprintf(fname, "%s/Halos/halonl_z%.3f_N%ld_L%.1f.dat.catalog",argv[1],redshift,global_N_smooth,global_L/global_hubble);
+    sprintf(fname, "%s/Halos/halonl_z%.3f_N%ld_L%.1f.dat.catalog",argv[1],redshift,global_N_halo,global_L/global_hubble);
     fid=fopen(fname,"rb");
     if (fid==NULL) {printf("\nError reading %s file... Check path or if the file exists...",fname); exit (1);}
     elem=fread(&nhalos,sizeof(long int),1,fid);
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
 
     // CIC smooth Rion//
     for(i=0;i<nhalos;i++){
-      CIC_smoothing(halo_v[i].x, halo_v[i].y, halo_v[i].z, Rion(halo_v[i].Mass, redshift), halo_map, global_N_halo);
+      CIC_smoothing(halo_v[i].x, halo_v[i].y, halo_v[i].z, Rion(halo_v[i].Mass, redshift), halo_map, global_N_smooth);
     }
 
     /* Quick fill of single cells before going to bubble cycle */

--- a/get_HIIbubbles.c
+++ b/get_HIIbubbles.c
@@ -5,8 +5,8 @@ Module: get_HIIbubbles
 Description: Generates a 3d box with global_N_smooth^3 cells witho 0s (neutral) and 1s (ionized)
 Input: the base directory where we find the parameter file simfast21.ini
 Output: creates base_dir/Ionization if needed
-For further details see: 
-M. G. Santos, L. Ferramacho, M. B. Silva, A. Amblard, A. Cooray, MNRAS 2010, http://arxiv.org/abs/0911.2219 
+For further details see:
+M. G. Santos, L. Ferramacho, M. B. Silva, A. Amblard, A. Cooray, MNRAS 2010, http://arxiv.org/abs/0911.2219
 *************************************************************************************************************/
 
 #ifdef _OMPTHREAD_
@@ -38,14 +38,14 @@ double XHI(double ratio);
 
 
 int main(int argc, char *argv[]) {
-  
+
   char fname[300];
   FILE *fid;
   DIR* dir;
   long int nhalos;
   Halo_t *halo_v;
   size_t elem;
-  long int ii,ij,ik, ii_c, ij_c, ik_c, a, b, c;   
+  long int ii,ij,ik, ii_c, ij_c, ik_c, a, b, c;
   long int ncells_1D;
   long int i,j,p,indi,indj,ind;
   int flag_bub,iz;
@@ -53,26 +53,26 @@ int main(int argc, char *argv[]) {
   double kk;
   double bfactor; /* value by which to divide bubble size R */
   double neutral,*xHI;
-  float *halo_map, *top_hat_r, *density_map,*bubblef, *bubble, *fresid;  
+  float *halo_map, *top_hat_r, *density_map,*bubblef, *bubble, *fresid;
   fftwf_complex *halo_map_c, *top_hat_c, *collapsed_mass_c, *density_map_c, *total_mass_c, *bubble_c;
   fftwf_plan pr2c1,pr2c2,pr2c3,pr2c4,pc2r1,pc2r2,pc2r3;
   double zmin,zmax,dz;
   double R;
-  
-  
+
+
   if(argc != 2) {
     printf("Generates boxes with ionization fraction for a range of redshifts\n");
     printf("usage: get_HIIbubbles base_dir\n");
     printf("base_dir contains simfast21.ini and directory structure\n");
     exit(1);
-  }  
+  }
   get_Simfast21_params(argv[1]);
   zmin=global_Zminsim;
   zmax=global_Zmaxsim;
   dz=global_Dzsim;
   bfactor=pow(10.0,log10(global_bubble_Rmax/global_dx_smooth)/global_bubble_Nbins);
   printf("Bubble radius ratio (bfactor): %f\n", bfactor); fflush(0);
- 
+
 #ifdef _OMPTHREAD_
   omp_set_num_threads(global_nthreads);
   fftwf_init_threads();
@@ -81,28 +81,28 @@ int main(int argc, char *argv[]) {
 #endif
   /* Create directory Ionization */
   sprintf(fname,"%s/Ionization",argv[1]);
-  if((dir=opendir(fname))==NULL) {  
+  if((dir=opendir(fname))==NULL) {
     printf("Creating Ionization directory\n");
     if(mkdir(fname,(S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH))!=0) {
       printf("Error creating directory!\n");
       exit(1);
     }
-  }    
+  }
   sprintf(fname,"%s/Output_text_files",argv[1]);
-  if((dir=opendir(fname))==NULL) {  
+  if((dir=opendir(fname))==NULL) {
     printf("Creating Output_text_files directory\n");
     if(mkdir(fname,(S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH))!=0) {
       printf("Error creating directory!\n");
       exit(1);
     }
-  }  
-  
-  
-  
+  }
+
+
+
  /* Memory allocation - we could do some of the FFTs inline... */
  /*************************************************************/
-  
-  /* density_map mass */ 
+
+  /* density_map mass */
   if(!(density_map=(float *) fftwf_malloc(global_N3_smooth*sizeof(float)))) {
     printf("Problem1...\n");
     exit(1);
@@ -111,11 +111,11 @@ int main(int argc, char *argv[]) {
     printf("Problem2...\n");
     exit(1);
   }
-  if(!(pr2c1=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, density_map, density_map_c, FFTWflag))) { 
+  if(!(pr2c1=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, density_map, density_map_c, FFTWflag))) {
     printf("Problem3...\n");
     exit(1);
-  }  
-  /* halo_map mass */ 
+  }
+  /* halo_map mass */
   if(!(halo_map=(float *) fftwf_malloc(global_N3_smooth*sizeof(float)))) {
     printf("Problem4...\n");
     exit(1);
@@ -124,28 +124,28 @@ int main(int argc, char *argv[]) {
     printf("Problem5...\n");
     exit(1);
   }
-  if(!(pr2c2=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, halo_map, halo_map_c, FFTWflag))) { 
+  if(!(pr2c2=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, halo_map, halo_map_c, FFTWflag))) {
     printf("Problem6...\n");
     exit(1);
-  }  
+  }
   /* total mass */
   if(!(total_mass_c=(fftwf_complex *) fftwf_malloc(global_N_smooth*global_N_smooth*(global_N_smooth/2+1)*sizeof(fftwf_complex)))) {
     printf("Problem7...\n");
     exit(1);
   }
-  if(!(pc2r1=fftwf_plan_dft_c2r_3d(global_N_smooth, global_N_smooth, global_N_smooth, total_mass_c, density_map, FFTWflag))) { 
+  if(!(pc2r1=fftwf_plan_dft_c2r_3d(global_N_smooth, global_N_smooth, global_N_smooth, total_mass_c, density_map, FFTWflag))) {
     printf("Problem8...\n");
     exit(1);
-  }    
+  }
   /* collapsed mass */
   if(!(collapsed_mass_c=(fftwf_complex *) fftwf_malloc(global_N_smooth*global_N_smooth*(global_N_smooth/2+1)*sizeof(fftwf_complex)))) {
     printf("Problem9...\n");
     exit(1);
   }
-  if(!(pc2r2=fftwf_plan_dft_c2r_3d(global_N_smooth, global_N_smooth, global_N_smooth, collapsed_mass_c, halo_map, FFTWflag))) { 
+  if(!(pc2r2=fftwf_plan_dft_c2r_3d(global_N_smooth, global_N_smooth, global_N_smooth, collapsed_mass_c, halo_map, FFTWflag))) {
     printf("Problem10...\n");
     exit(1);
-  }  
+  }
   /* top hat window */
   if(!(top_hat_r=(float *) fftwf_malloc(global_N3_smooth*sizeof(float)))) {
     printf("Problem11...\n");
@@ -155,10 +155,10 @@ int main(int argc, char *argv[]) {
     printf("Problem12...\n");
     exit(1);
   }
-  if(!(pr2c3=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, top_hat_r, top_hat_c, FFTWflag))) { 
+  if(!(pr2c3=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, top_hat_r, top_hat_c, FFTWflag))) {
     printf("Problem13...\n");
     exit(1);
-  } 
+  }
   /* bubble boxes */
   if(!(bubble=(float *) fftwf_malloc(global_N3_smooth*sizeof(float)))) {
     printf("Problem14...\n");
@@ -172,14 +172,14 @@ int main(int argc, char *argv[]) {
     printf("Problem16...\n");
     exit(1);
   }
-  if(!(pr2c4=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, bubble, bubble_c, FFTWflag))) { 
+  if(!(pr2c4=fftwf_plan_dft_r2c_3d(global_N_smooth, global_N_smooth, global_N_smooth, bubble, bubble_c, FFTWflag))) {
     printf("Problem17...\n");
     exit(1);
-  } 
-  if(!(pc2r3=fftwf_plan_dft_c2r_3d(global_N_smooth, global_N_smooth, global_N_smooth, bubble_c, bubble, FFTWflag))) { 
+  }
+  if(!(pc2r3=fftwf_plan_dft_c2r_3d(global_N_smooth, global_N_smooth, global_N_smooth, bubble_c, bubble, FFTWflag))) {
     printf("Problem18...\n");
     exit(1);
-  }  
+  }
   if(!(xHI=(double *) malloc((int)((zmax-zmin)/dz+2)*sizeof(double)))) {
     printf("Problem19...\n");
     exit(1);
@@ -189,45 +189,45 @@ int main(int argc, char *argv[]) {
     exit(1);
   }
 
-  
+
   /****************************************************/
   /***************** Redshift cycle *******************/
   printf("Number of bubble sizes: %d\n",(int)((log(global_bubble_Rmax)-log(2.*global_dx_smooth))/log(bfactor)));
   printf("Redshift cycle...\n");fflush(0);
   iz=0;
   neutral=0.;
-  for(redshift=zmin;redshift<(zmax+dz/10) && (neutral < global_xHlim);redshift+=dz){    
+  for(redshift=zmin;redshift<(zmax+dz/10) && (neutral < global_xHlim);redshift+=dz){
     printf("z = %f\n",redshift);fflush(0);
 
-    sprintf(fname, "%s/delta/deltanl_z%.3f_N%ld_L%.1f.dat",argv[1],redshift,global_N_smooth,global_L/global_hubble); 
+    sprintf(fname, "%s/delta/deltanl_z%.3f_N%ld_L%.1f.dat",argv[1],redshift,global_N_smooth,global_L/global_hubble);
     fid=fopen(fname,"rb");
     if (fid==NULL) {printf("\nError reading deltanl file... Check path or if the file exists..."); exit (1);}
     elem=fread(density_map,sizeof(float),global_N3_smooth,fid);
     fclose(fid);
-    
+
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(global_N3_smooth, density_map, fresid, bubblef, halo_map, redshift) private(i)
 #endif
     for(i=0;i<(global_N3_smooth);i++){
-      fresid[i] = (1. + density_map[i])*1.881e-7*pow(1.+redshift,3.0)*G_H(redshift); // ratio between hydrogen recombination coefficient and uniform ionising background (Haardt & Madau (2012)). 
+      fresid[i] = (1. + density_map[i])*1.881e-7*pow(1.+redshift,3.0)*G_H(redshift); // ratio between hydrogen recombination coefficient and uniform ionising background (Haardt & Madau (2012)).
       fresid[i] = XHI(fresid[i]); // Residual neutral fraction following Popping et al. (2009).
-      density_map[i]= Rrec(1.0+density_map[i], redshift); // Rrec from the CIC smoothed-nonlinear density field. 
+      density_map[i]= Rrec(1.0+density_map[i], redshift); // Rrec from the CIC smoothed-nonlinear density field.
       bubblef[i]=0.0;
       halo_map[i] =0.0;
     }
 
-    sprintf(fname, "%s/Halos/halonl_z%.3f_N%ld_L%.1f.dat.catalog",argv[1],redshift,global_N_smooth,global_L/global_hubble); 
+    sprintf(fname, "%s/Halos/halonl_z%.3f_N%ld_L%.1f.dat.catalog",argv[1],redshift,global_N_smooth,global_L/global_hubble);
     fid=fopen(fname,"rb");
     if (fid==NULL) {printf("\nError reading %s file... Check path or if the file exists...",fname); exit (1);}
     elem=fread(&nhalos,sizeof(long int),1,fid);
     printf("Reading %ld halos...\n",nhalos);fflush(0);
-    if(!(halo_v=(Halo_t *) malloc(nhalos*sizeof(Halo_t)))) { 
+    if(!(halo_v=(Halo_t *) malloc(nhalos*sizeof(Halo_t)))) {
       printf("Problem - halo...\n");
       exit(1);
     }
     elem=fread(halo_v,sizeof(Halo_t),nhalos,fid);
     fclose(fid);
-    
+
     // CIC smooth Rion//
     for(i=0;i<nhalos;i++){
       CIC_smoothing(halo_v[i].x, halo_v[i].y, halo_v[i].z, Rion(halo_v[i].Mass, redshift), halo_map, global_N_halo);
@@ -239,7 +239,7 @@ int main(int argc, char *argv[]) {
 #endif
     for(i=0;i<global_N3_smooth;i++) {
       if(halo_map[i]>0.) {
-	if(density_map[i]>0.) 
+	if(density_map[i]>0.)
 	  tmp=(double)halo_map[i]/density_map[i];
 	else tmp=1.0;
       }else tmp=0.;
@@ -249,21 +249,21 @@ int main(int argc, char *argv[]) {
     fftwf_execute(pr2c1);    /* FFT density map */
     fftwf_execute(pr2c2);   /* FFT halo map */
 
-    
+
     /************** going over the bubble sizes ****************/
     R=global_bubble_Rmax;    /* Maximum bubble size...*/
-    while(R>=2*global_dx_smooth){ 
-    
-      printf("bubble radius R= %lf\n", R);fflush(0);    
+    while(R>=2*global_dx_smooth){
+
+      printf("bubble radius R= %lf\n", R);fflush(0);
       //      printf("Filtering halo and density boxes...\n");fflush(0);
-    
+
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(collapsed_mass_c,halo_map_c,total_mass_c,density_map_c,global_N_smooth,global_dk,R) private(i,j,p,indi,indj,kk)
 #endif
       for(i=0;i<global_N_smooth;i++) {
 	if(i>global_N_smooth/2) {
 	  indi=-(global_N_smooth-i);
-	}else indi=i;      
+	}else indi=i;
 	for(j=0;j<global_N_smooth;j++) {
 	  if(j>global_N_smooth/2) {
 	    indj=-(global_N_smooth-j);
@@ -275,56 +275,56 @@ int main(int argc, char *argv[]) {
 	  }
 	}
       }
-      
+
       fftwf_execute(pc2r1);     /* FFT back filtered density map */
       fftwf_execute(pc2r2);     /* FFT back filtered halo map */
-      
+
       flag_bub=0;
-      
+
       //      printf("Starting to find and fill bubbles...\n");fflush(0);
 
-      /* signal center of bubbles */      
+      /* signal center of bubbles */
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(halo_map,density_map, bubble, global_N_smooth,flag_bub) private(ii,ij,ik,ind)
-#endif  
+#endif
       for(ii=0;ii<global_N_smooth;ii++){
 	for(ij=0;ij<global_N_smooth;ij++){
 	  for(ik=0;ik<global_N_smooth;ik++){
 	    ind=ii*global_N_smooth*global_N_smooth+ij*global_N_smooth+ik;
 	    if(halo_map[ind]>0.) {
-	      if(density_map[ind]>0.) { 
+	      if(density_map[ind]>0.) {
 		if((double)halo_map[ind]/density_map[ind]>=1.0) {
 		  flag_bub=1;
-		  bubble[ind]=1.0;  	     	    	    
+		  bubble[ind]=1.0;
 		}else bubble[ind]=0;
 	      }else {
 		flag_bub=1;
-		bubble[ind]=1.0;  	     	    	    
+		bubble[ind]=1.0;
 	      }
 	    }else bubble[ind]=0;
 	  }
 	}
       }
-    
+
       /* generate spherical window in real space for a given R */
       if(flag_bub>0){
 	printf("Found bubble...\n");fflush(0);
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(top_hat_r,R,global_dx_smooth,global_N_smooth) private(i,j,p)
-#endif  
+#endif
 	for(i=0;i<global_N_smooth;i++){
 	  for(j=0;j<global_N_smooth;j++){
-	    for(p=0;p<global_N_smooth;p++){ 
+	    for(p=0;p<global_N_smooth;p++){
 	      if(sqrt(i*i+j*j+p*p)*global_dx_smooth<=R || sqrt(i*i+(j-global_N_smooth)*(j-global_N_smooth)+p*p)*global_dx_smooth<=R  || sqrt(i*i+(j-global_N_smooth)*(j-global_N_smooth)+(p-global_N_smooth)*(p-global_N_smooth))*global_dx_smooth <=R || sqrt(i*i+(p-global_N_smooth)*(p-global_N_smooth)+j*j)*global_dx_smooth<=R || sqrt((i-global_N_smooth)*(i-global_N_smooth)+j*j+p*p)*global_dx_smooth<=R ||  sqrt((i-global_N_smooth)*(i-global_N_smooth)+(j-global_N_smooth)*(j-global_N_smooth)+p*p)*global_dx_smooth<=R ||  sqrt((i-global_N_smooth)*(i-global_N_smooth)+(j-global_N_smooth)*(j-global_N_smooth)+(p-global_N_smooth)*(p-global_N_smooth))*global_dx_smooth<=R ||  sqrt((i-global_N_smooth)*(i-global_N_smooth)+j*j+(p-global_N_smooth)*(p-global_N_smooth))*global_dx_smooth<=R ) {
 		top_hat_r[i*global_N_smooth*global_N_smooth+j*global_N_smooth+p]=1.0;
-	      }else top_hat_r[i*global_N_smooth*global_N_smooth+j*global_N_smooth+p]=0.0;	  
+	      }else top_hat_r[i*global_N_smooth*global_N_smooth+j*global_N_smooth+p]=0.0;
 	    }
 	  }
 	}
-	/* FFT bubble centers and window */ 
+	/* FFT bubble centers and window */
 	fftwf_execute(pr2c3); /* FFT window */
 	fftwf_execute(pr2c4); /* FFT ionisation (bubble) box */
-      
+
 	/* Make convolution */
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(bubble_c,top_hat_c,global_N_smooth) private(i)
@@ -333,26 +333,26 @@ int main(int argc, char *argv[]) {
 	  bubble_c[i]*=top_hat_c[i];
 	}
 	fftwf_execute(pc2r3);     /* FFT back to real ionisation (bubble) box */
-	
-	/* after dividing by global_N3_smooth, values in bubble are between 0 (neutral)and global_N3_smooth  - this is now the full resolution box! (not the one smoothed over the scale) */     
+
+	/* after dividing by global_N3_smooth, values in bubble are between 0 (neutral)and global_N3_smooth  - this is now the full resolution box! (not the one smoothed over the scale) */
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(bubble,bubblef,global_N3_smooth) private(i)
 #endif
 	for (i=0; i<global_N3_smooth; i++){
 	  bubble[i]/=global_N3_smooth;
 	  if (bubble[i]>0.2) bubblef[i]=1.0; /* neutral should be zero */
-	} 
-	
+	}
+
       } /* ends filling out bubbles in box for R */
-    
-      R/=bfactor;  
+
+      R/=bfactor;
     } /* ends R cycle */
- 
+
     /* just to check smallest bubbles through older method */
     printf("Going to smaller R cycle...\n"); fflush(0);
     while(R>=global_dx_smooth){
-  
-      printf("bubble radius R= %lf\n", R);fflush(0); 
+
+      printf("bubble radius R= %lf\n", R);fflush(0);
       flag_bub=0;
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(collapsed_mass_c,halo_map_c,total_mass_c,density_map_c,global_N_smooth,global_dx_smooth,global_dk,R) private(i,j,p,indi,indj,kk)
@@ -360,7 +360,7 @@ int main(int argc, char *argv[]) {
       for(i=0;i<global_N_smooth;i++) {
 	if(i>global_N_smooth/2) {
 	  indi=-(global_N_smooth-i);
-	}else indi=i;      
+	}else indi=i;
 	for(j=0;j<global_N_smooth;j++) {
 	  if(j>global_N_smooth/2) {
 	    indj=-(global_N_smooth-j);
@@ -374,9 +374,9 @@ int main(int argc, char *argv[]) {
       }
       fftwf_execute(pc2r1);  /* FFT convolved density field - gives smoothed real density field */
       fftwf_execute(pc2r2);  /* FFT convolved halo filed - gives smoothed real halo field */
-   
+
       /* fill smaller bubbles in box */
-      ncells_1D=(long int)(R/global_dx_smooth);    
+      ncells_1D=(long int)(R/global_dx_smooth);
       //      printf("Starting to find and fill bubbles...\n");fflush(0);
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(halo_map,density_map,global_N_smooth,global_dx_smooth,R,ncells_1D,bubblef,flag_bub) private(ii_c,ij_c,ik_c,ii,ij,ik,a,b,c,ind)
@@ -396,7 +396,7 @@ int main(int argc, char *argv[]) {
 		      for(ik=-(ncells_1D+1);ik<=ncells_1D+1;ik++){
 			c=check_borders(ik_c+ik,global_N_smooth);
 			if(sqrt(ii*ii+ij*ij+ik*ik)*global_dx_smooth <= R){
-			  bubblef[a*global_N_smooth*global_N_smooth+b*global_N_smooth+c]=1.0;  	     
+			  bubblef[a*global_N_smooth*global_N_smooth+b*global_N_smooth+c]=1.0;
 			}
 		      }
 		    }
@@ -414,7 +414,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef _OMPTHREAD_
 #pragma omp parallel for shared(global_N3_smooth, bubblef, fresid) private(i)
-#endif   
+#endif
     for (i=0; i<global_N3_smooth; i++){
       if(bubblef[i] > 1.0 - fresid[i]) bubblef[i] = 1.0 - fresid[i];
     }
@@ -426,12 +426,12 @@ int main(int argc, char *argv[]) {
     neutral/=global_N3_smooth;
     printf("neutral fraction=%lf\n",neutral);fflush(0);
     xHI[iz]=neutral;
-    sprintf(fname, "%s/Ionization/xHII_z%.3f_N%ld_L%.1f.dat",argv[1],redshift,global_N_smooth,global_L/global_hubble); 
+    sprintf(fname, "%s/Ionization/xHII_z%.3f_N%ld_L%.1f.dat",argv[1],redshift,global_N_smooth,global_L/global_hubble);
     if((fid = fopen(fname,"wb"))==NULL) {
       printf("Error opening file:%s\n",fname);
       exit(1);
     }
-    elem=fwrite(bubblef,sizeof(float),global_N3_smooth,fid);  
+    elem=fwrite(bubblef,sizeof(float),global_N3_smooth,fid);
     fclose(fid);
     iz++;
   } /* ends redshift cycle */
@@ -441,7 +441,7 @@ int main(int argc, char *argv[]) {
   while(redshift<(zmax+dz/10)) {
     printf("z(>%f) = %f\n",global_xHlim,redshift);fflush(0);
     xHI[iz]=1.0;
-    sprintf(fname, "%s/Ionization/xHII_z%.3f_N%ld_L%.1f.dat",argv[1],redshift,global_N_smooth,global_L/global_hubble); 
+    sprintf(fname, "%s/Ionization/xHII_z%.3f_N%ld_L%.1f.dat",argv[1],redshift,global_N_smooth,global_L/global_hubble);
     if((fid = fopen(fname,"wb"))==NULL) {
       printf("Error opening file:%s\n",fname);
       exit(1);
@@ -450,11 +450,11 @@ int main(int argc, char *argv[]) {
 #pragma omp parallel for shared(bubblef,global_N3_smooth) private(i)
 #endif
     for(i=0;i<global_N3_smooth;i++) bubblef[i]=0.0;
-    elem=fwrite(bubblef,sizeof(float),global_N3_smooth,fid);  
+    elem=fwrite(bubblef,sizeof(float),global_N3_smooth,fid);
     fclose(fid);
     iz++;
     redshift+=dz;
-  }    
+  }
 
   sprintf(fname, "%s/Output_text_files/zsim.txt",argv[1]);
   if((fid = fopen(fname,"a"))==NULL) {
@@ -470,7 +470,7 @@ int main(int argc, char *argv[]) {
   }
   for(i=iz-1;i>=0;i--) fprintf(fid,"%lf\n",xHI[i]); /* first line should be highest redshift */
   fclose(fid);
-  
+
   free(xHI);
   free(bubblef);
   fftwf_free(top_hat_r);


### PR DESCRIPTION
In ``get_HIIbubbles.c``, the wrong ``global_N_smooth`` variable (which should be ``global_N_halo``) is used to determine the halo data file, which causes the error that the necessary input file is not exists, e.g.,

```
----------- Ionization fraction ------------
Bubble radius ratio (bfactor): 1.100484
Using 16 threads
Creating Ionization directory
Creating Output_text_files directory
Number of bubble sizes: 42
Redshift cycle...
z = 5.000000

Error reading output/Halos/halonl_z5.000_N300_L100.0.dat.catalog file... Check path o
r if the file exists...
```
(here, I use the default configurations with ``N_halo=600`` and ``N_smoothed=300``.)

Also fix the wrong ``global_N_halo`` variable used in function ``CIC_smoothing()`` with ``global_N_smooth``.


Regards,
Aly
